### PR TITLE
Feature/standard environment

### DIFF
--- a/STEP/AST/FunctionSymTableEntry.cs
+++ b/STEP/AST/FunctionSymTableEntry.cs
@@ -1,6 +1,4 @@
-﻿using STEP.AST.Nodes;
-
-namespace STEP.AST;
+﻿namespace STEP.AST;
 
 public class FunctionSymTableEntry : SymTableEntry
 {

--- a/STEP/AST/Nodes/TypeVal.cs
+++ b/STEP/AST/Nodes/TypeVal.cs
@@ -10,4 +10,5 @@ public enum TypeVal
     Digitalpin,
     Blank,
     Ok,
+    PinLevel, // HIGH, LOW
 }

--- a/STEP/AST/StandardEnvironment.cs
+++ b/STEP/AST/StandardEnvironment.cs
@@ -59,7 +59,7 @@ public static class StandardEnvironment
         {
             {"pin", new PinType() {ActualType = TypeVal.Analogpin}}
         },
-        Type = new Type() { ActualType = TypeVal.PinLevel, IsConstant = true }
+        Type = new Type() { ActualType = TypeVal.Number }
     };
     public static StdFuncSymTableEntry AnalogWrite => new()
     {
@@ -68,7 +68,7 @@ public static class StandardEnvironment
         Parameters = new()
         {
             { "pin", new PinType { ActualType = TypeVal.Analogpin } },
-            { "value", new Type { ActualType = TypeVal.PinLevel } }
+            { "value", new Type { ActualType = TypeVal.Number } }
         },
         Type = new Type { ActualType = TypeVal.Blank }
     };

--- a/STEP/AST/StandardEnvironment.cs
+++ b/STEP/AST/StandardEnvironment.cs
@@ -4,40 +4,44 @@ namespace STEP.AST;
 
 public static class StandardEnvironment
 {
-    // Constants
-    public static SymTableEntry High => new()
+    #region Constants
+    public static StdSymTableEntry High => new()
     {
-        Name = "HIGH",
+        Name = "High",
+        ArduinoName = "HIGH",
         Type = new Type
         {
             ActualType = TypeVal.PinLevel,
             IsConstant = true
         }
     };
-    public static SymTableEntry Low => new()
+    public static StdSymTableEntry Low => new()
     {
-        Name = "LOW",
+        Name = "Low",
+        ArduinoName = "LOW",
         Type = new Type
         {
             ActualType = TypeVal.PinLevel,
             IsConstant = true
         }
     };
-    
-    // Digital I/O
-    // digitalRead(), digitalWrite(), pinMode()
-    public static FunctionSymTableEntry DigitalRead => new()
+    #endregion
+
+    #region I/O
+    public static StdFuncSymTableEntry DigitalRead => new()
     {
-        Name = "digitalRead",
+        Name = "ReadFromDigitalPin",
+        ArduinoName = "digitalRead",
         Parameters = new Dictionary<string, Type>
         {
             {"pin", new PinType() {ActualType = TypeVal.Digitalpin}}
         },
         Type = new Type() { ActualType = TypeVal.PinLevel, IsConstant = true}
     };
-    public static FunctionSymTableEntry DigitalWrite => new()
+    public static StdFuncSymTableEntry DigitalWrite => new()
     {
-        Name = "digitalWrite",
+        Name = "WriteToDigitalPin",
+        ArduinoName = "digitalWrite",
         Parameters = new()
         {
             { "pin", new PinType { ActualType = TypeVal.Digitalpin } },
@@ -46,23 +50,196 @@ public static class StandardEnvironment
         Type = new Type { ActualType = TypeVal.Blank }
     };
 
-    // Analog I/O
-    // analagRead(), analogReference(), analogWrite()
+    // analagRead(), analogWrite()
+    public static StdFuncSymTableEntry AnalogRead => new()
+    {
+        Name = "ReadFromAnalogPin",
+        ArduinoName = "analogRead",
+        Parameters = new Dictionary<string, Type>
+        {
+            {"pin", new PinType() {ActualType = TypeVal.Analogpin}}
+        },
+        Type = new Type() { ActualType = TypeVal.PinLevel, IsConstant = true }
+    };
+    public static StdFuncSymTableEntry AnalogWrite => new()
+    {
+        Name = "WriteToAnalogPin",
+        ArduinoName = "analogWrite",
+        Parameters = new()
+        {
+            { "pin", new PinType { ActualType = TypeVal.Analogpin } },
+            { "value", new Type { ActualType = TypeVal.PinLevel } }
+        },
+        Type = new Type { ActualType = TypeVal.Blank }
+    };
 
-    // I/O (Serial)
-    // print(), 
+    // Serial.println(string)
+    public static StdFuncSymTableEntry Print => new()
+    {
+        Name = "Print",
+        ArduinoName = "Serial.println",
+        Parameters = new()
+        {
+            { "message", new Type { ActualType = TypeVal.String } }
+        },
+        Type = new Type { ActualType = TypeVal.Blank }
+    };
+    #endregion
 
-    // Time
-    // delay(), delayMicroseconds(), micros(), millis()
+    #region Time
+    // delay(unsigned long)
+    public static StdFuncSymTableEntry Delay => new()
+    {
+        Name = "Wait",
+        ArduinoName = "delay",
+        Parameters = new()
+        {
+            { "ms", new Type { ActualType = TypeVal.Number } }
+        },
+        Type = new Type { ActualType = TypeVal.Blank }
+    };
+    #endregion
 
-    // Math
-    // abs(), constrain(), map(), max(), min(), pow(), sq(), sqrt()
+    #region Math
+    public static StdFuncSymTableEntry Abs => new()
+    {
+        Name = "AbsoluteValue",
+        ArduinoName = "abs",
+        Parameters = new()
+        {
+            { "x", new Type { ActualType = TypeVal.Number } }
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry Constrain => new()
+    {
+        Name = "ConstrainValue",
+        ArduinoName = "constrain",
+        Parameters = new()
+        {
+            { "x", new Type { ActualType = TypeVal.Number } },
+            { "upperLimit", new Type { ActualType = TypeVal.Number } },
+            { "lowerLimit", new Type { ActualType = TypeVal.Number } }
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry Max => new()
+    {
+        Name = "Max",
+        ArduinoName = "max",
+        Parameters = new()
+        {
+            { "x", new Type { ActualType = TypeVal.Number } },
+            { "y", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry Min => new()
+    {
+        Name = "Min",
+        ArduinoName = "min",
+        Parameters = new()
+        {
+            { "x", new Type { ActualType = TypeVal.Number } },
+            { "y", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry Power => new()
+    {
+        Name = "Power",
+        ArduinoName = "pow",
+        Parameters = new()
+        {
+            { "base", new Type { ActualType = TypeVal.Number } },
+            { "exponent", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry Squared => new()
+    {
+        Name = "Squared",
+        ArduinoName = "sq",
+        Parameters = new()
+        {
+            { "x", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry SquareRoot => new()
+    {
+        Name = "SquareRoot",
+        ArduinoName = "sqrt",
+        Parameters = new()
+        {
+            { "x", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
 
     // Trigonometry
-    // cos(), sin(), tan()
+    public static StdFuncSymTableEntry Cosine => new()
+    {
+        Name = "Cosine",
+        ArduinoName = "cos",
+        Parameters = new()
+        {
+            { "rad", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
 
-    // Random numbers
-    // random(), randomSeed()
+    public static StdFuncSymTableEntry Sine => new()
+    {
+        Name = "Sine",
+        ArduinoName = "sin",
+        Parameters = new()
+        {
+            { "rad", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
 
-    // 
+    public static StdFuncSymTableEntry Tangent => new()
+    {
+        Name = "Tangent",
+        ArduinoName = "tan",
+        Parameters = new()
+        {
+            { "rad", new Type { ActualType = TypeVal.Number } },
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+    #endregion
+
+    #region Random numbers
+    public static StdFuncSymTableEntry Random => new()
+    {
+        Name = "Random",
+        ArduinoName = "random",
+        Parameters = new()
+        {
+            { "min", new Type { ActualType = TypeVal.Number } },
+            { "max", new Type { ActualType = TypeVal.Number } }
+        },
+        Type = new Type { ActualType = TypeVal.Number }
+    };
+
+    public static StdFuncSymTableEntry RandomSeed => new()
+    {
+        Name = "RandomSeed",
+        ArduinoName = "randomSeed",
+        Parameters = new()
+        {
+            { "seed", new Type { ActualType = TypeVal.Number } }
+        },
+        Type = new Type { ActualType = TypeVal.Blank }
+    };
+    #endregion
 }

--- a/STEP/AST/StandardEnvironment.cs
+++ b/STEP/AST/StandardEnvironment.cs
@@ -5,35 +5,45 @@ namespace STEP.AST;
 public static class StandardEnvironment
 {
     // Constants
-    public static SymTableEntry High => new SymTableEntry
+    public static SymTableEntry High => new()
     {
         Name = "HIGH",
         Type = new Type
         {
-            ActualType = TypeVal.Number,
+            ActualType = TypeVal.PinLevel,
             IsConstant = true
         }
     };
-    public static SymTableEntry Low => new SymTableEntry
+    public static SymTableEntry Low => new()
     {
         Name = "LOW",
         Type = new Type
         {
-            ActualType = TypeVal.Number,
+            ActualType = TypeVal.PinLevel,
             IsConstant = true
         }
     };
     
     // Digital I/O
     // digitalRead(), digitalWrite(), pinMode()
-    public static FunctionSymTableEntry DigitalRead => new FunctionSymTableEntry()
+    public static FunctionSymTableEntry DigitalRead => new()
     {
         Name = "digitalRead",
         Parameters = new Dictionary<string, Type>
         {
             {"pin", new PinType() {ActualType = TypeVal.Digitalpin}}
         },
-        Type = new Type() { ActualType = TypeVal.Number, IsConstant = true}
+        Type = new Type() { ActualType = TypeVal.PinLevel, IsConstant = true}
+    };
+    public static FunctionSymTableEntry DigitalWrite => new()
+    {
+        Name = "digitalWrite",
+        Parameters = new()
+        {
+            { "pin", new PinType { ActualType = TypeVal.Digitalpin } },
+            { "value", new Type { ActualType = TypeVal.PinLevel } }
+        },
+        Type = new Type { ActualType = TypeVal.Blank }
     };
 
     // Analog I/O

--- a/STEP/AST/StdFuncSymTableEntry.cs
+++ b/STEP/AST/StdFuncSymTableEntry.cs
@@ -1,0 +1,6 @@
+﻿namespace STEP.AST;
+
+public class StdFuncSymTableEntry : FunctionSymTableEntry
+{
+    public string ArduinoName { get; set; }
+}

--- a/STEP/AST/StdSymTableEntry.cs
+++ b/STEP/AST/StdSymTableEntry.cs
@@ -1,0 +1,6 @@
+﻿namespace STEP.AST;
+
+public class StdSymTableEntry : SymTableEntry
+{
+    public string ArduinoName { get; set; }
+}

--- a/STEP/AST/SymbolTable.cs
+++ b/STEP/AST/SymbolTable.cs
@@ -24,6 +24,7 @@ public class SymbolTable : ISymbolTable
         EnterSymbol(StandardEnvironment.High);
         EnterSymbol(StandardEnvironment.Low);
         EnterSymbol(StandardEnvironment.DigitalRead);
+        EnterSymbol(StandardEnvironment.DigitalWrite);
     }
     
     public void OpenScope()

--- a/STEP/AST/SymbolTable.cs
+++ b/STEP/AST/SymbolTable.cs
@@ -21,12 +21,32 @@ public class SymbolTable : ISymbolTable
 
     private void AddStandardEnvironment()
     {
+        // Constants
         EnterSymbol(StandardEnvironment.High);
         EnterSymbol(StandardEnvironment.Low);
+        // I/O
         EnterSymbol(StandardEnvironment.DigitalRead);
         EnterSymbol(StandardEnvironment.DigitalWrite);
+        EnterSymbol(StandardEnvironment.AnalogRead);
+        EnterSymbol(StandardEnvironment.AnalogWrite);
+        EnterSymbol(StandardEnvironment.Print);
+        // Math
+        EnterSymbol(StandardEnvironment.Min);
+        EnterSymbol(StandardEnvironment.Max);
+        EnterSymbol(StandardEnvironment.Constrain);
+        EnterSymbol(StandardEnvironment.Sine);
+        EnterSymbol(StandardEnvironment.Cosine);
+        EnterSymbol(StandardEnvironment.Squared);
+        EnterSymbol(StandardEnvironment.SquareRoot);
+        EnterSymbol(StandardEnvironment.Abs);
+        EnterSymbol(StandardEnvironment.Power);
+        // Random
+        EnterSymbol(StandardEnvironment.Random);
+        EnterSymbol(StandardEnvironment.RandomSeed);
+        // Time
+        EnterSymbol(StandardEnvironment.Delay);
     }
-    
+
     public void OpenScope()
     {
         this._depth++;

--- a/StepTests/StandardEnvironmentTests.cs
+++ b/StepTests/StandardEnvironmentTests.cs
@@ -36,13 +36,13 @@ public class StandardEnvironmentTests
         };
         var digitalRead = new FuncExprNode
         {
-            Id = new IdNode {Id = "digitalRead"},
+            Id = new IdNode {Id = "ReadFromDigitalPin" },
             Params = new List<ExprNode> {new IdNode {Id = "p"}}
         };
         var condition = new EqNode
         {
             Left = digitalRead,
-            Right = new IdNode {Id = "HIGH"}
+            Right = new IdNode {Id = "High"}
         };
         var ifStmt = new IfNode
         {
@@ -79,12 +79,12 @@ public class StandardEnvironmentTests
     [Fact]
     public void DigitalRead_InvalidParameter_ThrowsTypeException()
     {
-        // digitalRead(1) -> type exception since 1 is not a digitalpin!
+        // ReadFromDigitalPin(1) -> type exception since 1 is not a digitalpin!
 
         // Arrange
         var digitalRead = new FuncExprNode
         {
-            Id = new IdNode { Id = "digitalRead" },
+            Id = new IdNode { Id = "ReadFromDigitalPin" },
             Params = new List<ExprNode> { new NumberNode { Value = 1 } }
         };
         
@@ -108,8 +108,8 @@ public class StandardEnvironmentTests
         // Arrange
         var digitalWrite = new FuncStmtNode
         {
-            Id = new IdNode { Id = "digitalWrite" },
-            Params = new List<ExprNode> { new IdNode { Id = "p" }, new IdNode { Id = "LOW" } }
+            Id = new IdNode { Id = "WriteToDigitalPin" },
+            Params = new List<ExprNode> { new IdNode { Id = "p" }, new IdNode { Id = "Low" } }
         };
         var pinDcl = new PinDclNode
         {

--- a/StepTests/StandardEnvironmentTests.cs
+++ b/StepTests/StandardEnvironmentTests.cs
@@ -94,4 +94,46 @@ public class StandardEnvironmentTests
         // Assert
         Assert.Throws<TypeException>(test);
     }
+
+    [Fact]
+    public void DigitalWrite_ValidParameters_ThrowsNoException()
+    {
+        /*
+         * blank function x()
+         *   input digitalpin p = 1
+         *   digitalWrite(p, LOW)
+         * end function
+         */
+
+        // Arrange
+        var digitalWrite = new FuncStmtNode
+        {
+            Id = new IdNode { Id = "digitalWrite" },
+            Params = new List<ExprNode> { new IdNode { Id = "p" }, new IdNode { Id = "LOW" } }
+        };
+        var pinDcl = new PinDclNode
+        {
+            Left = new IdNode
+            {
+                Id = "p",
+                Type = new PinType
+                {
+                    ActualType = TypeVal.Digitalpin,
+                    IsConstant = true,
+                    Mode = PinMode.INPUT
+                }
+            },
+            Right = new NumberNode { Value = 1 }
+        };
+        var funcDcl = new FuncDefNode
+        {
+            Name = new IdNode { Id = "x" },
+            Stmts = new List<StmtNode> { pinDcl, digitalWrite },
+            FormalParams = new List<IdNode>(),
+            ReturnType = new Type { ActualType = TypeVal.Blank }
+        };
+
+        // Act, assert
+        _typeVisitor.Visit(funcDcl);
+    }
 }


### PR DESCRIPTION
With this feature, the compiler is able to recognize standard functions such as `digitalWrite()`, which means that they will not lead to any errors with missing declarations. 
The next next step is to translate our alias' to the Arduino names, for example `WriteToDigitalPin() => digitalWrite()`, but this requires some work on the symbol table, which is the next step! 